### PR TITLE
Refactor : 배치 로직 디벨롭

### DIFF
--- a/Attendance/.gitignore
+++ b/Attendance/.gitignore
@@ -41,5 +41,5 @@ build/
 .vscode/
 
 
-src/main/resources/woven-coral-441407-d3-59f4b86ecd42.json
+src/main/resources/zgsj-448911-a45213912f8e.json
 src/main/resources/application.yml

--- a/Attendance/.gitignore
+++ b/Attendance/.gitignore
@@ -42,4 +42,4 @@ build/
 
 
 src/main/resources/woven-coral-441407-d3-59f4b86ecd42.json
-#src/main/resources
+src/main/resources/application.yml

--- a/Attendance/build.gradle
+++ b/Attendance/build.gradle
@@ -43,6 +43,11 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	//서킷 브레이커 위한 의존성
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
+	implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	implementation 'org.xhtmlrenderer:flying-saucer-core:9.1.22'
 	implementation 'org.xhtmlrenderer:flying-saucer-pdf-itext5:9.1.22'
 	implementation 'com.itextpdf:itextpdf:5.5.13.3'

--- a/Attendance/src/main/java/com/example/Attendance/config/FeignConfig.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/FeignConfig.java
@@ -11,6 +11,6 @@ public class FeignConfig {
         // period: 초기 재시도 간격(ms)
         // maxPeriod: 최대 재시도 간격(ms)
         // maxAttempts: 최대 재시도 횟수
-        return new Retryer.Default(60000, 60000, 3);
+        return new Retryer.Default(10000, 10000, 3);
     }
 }

--- a/Attendance/src/main/java/com/example/Attendance/config/FeignConfig.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/FeignConfig.java
@@ -1,16 +1,16 @@
-package com.example.Attendance.config;
-
-import feign.Retryer;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class FeignConfig {
-    @Bean
-    public Retryer retryer() {
-        // period: 초기 재시도 간격(ms)
-        // maxPeriod: 최대 재시도 간격(ms)
-        // maxAttempts: 최대 재시도 횟수
-        return new Retryer.Default(10000, 10000, 3);
-    }
-}
+//package com.example.Attendance.config;
+//
+//import feign.Retryer;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//@Configuration
+//public class FeignConfig {
+//    @Bean
+//    public Retryer retryer() {
+//        // period: 초기 재시도 간격(ms)
+//        // maxPeriod: 최대 재시도 간격(ms)
+//        // maxAttempts: 최대 재시도 횟수
+//        return new Retryer.Default(10000, 10000, 3);
+//    }
+//}

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/AttendanceBatchJobListener.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/AttendanceBatchJobListener.java
@@ -5,10 +5,13 @@ import com.example.Attendance.config.attendanceJob.step.email.EmailBatchState;
 import com.example.Attendance.config.attendanceJob.step.pdf.PdfBatchState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 @Slf4j
@@ -19,16 +22,79 @@ public class AttendanceBatchJobListener {
     private final PdfBatchState pdfBatchState;
     private final EmailBatchState emailBatchState;
     private final SalaryBatchState salaryBatchState;
+    private final Map<String, Long> stepStartTimes = new ConcurrentHashMap<>();
 
+//    @Bean
+//    public JobExecutionListener attendanceJobListener() {
+//        return new JobExecutionListener() {
+//            @Override
+//            public void afterJob(JobExecution jobExecution) {
+//                pdfBatchState.reset();
+//                emailBatchState.reset();
+//                salaryBatchState.reset();
+//            }
+//        };
+//    }
+
+    //타임 check
     @Bean
     public JobExecutionListener attendanceJobListener() {
         return new JobExecutionListener() {
+            @Override
+            public void beforeJob(JobExecution jobExecution) {
+                log.info("==== Job '{}' 시작 ====", jobExecution.getJobInstance().getJobName());
+                stepStartTimes.clear(); // 시작 시 초기화
+            }
+
             @Override
             public void afterJob(JobExecution jobExecution) {
                 pdfBatchState.reset();
                 emailBatchState.reset();
                 salaryBatchState.reset();
+                long jobExecutionTime = java.time.Duration.between(
+                        jobExecution.getStartTime(),
+                        jobExecution.getEndTime()
+                ).toMillis();
+                log.info("==== Job 전체 실행 시간: {} ms ====", jobExecutionTime);
+
+                for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+                    long executionTime = java.time.Duration.between(
+                            stepExecution.getStartTime(),
+                            stepExecution.getEndTime()
+                    ).toMillis();
+
+                    log.info("==== Step '{}' 실행 통계 ====", stepExecution.getStepName());
+                    log.info("실행 시간: {} ms", executionTime);
+                    log.info("읽은 아이템 수: {}", stepExecution.getReadCount());
+                    log.info("처리된 아이템 수: {}", stepExecution.getWriteCount());
+                    log.info("건너뛴 아이템 수: {}", stepExecution.getSkipCount());
+                    if (Objects.nonNull(stepExecution.getFailureExceptions()) && !stepExecution.getFailureExceptions().isEmpty()) {
+                        log.info("실패 원인: {}", stepExecution.getFailureExceptions());
+                    }
+                    log.info("==========================");
+                }
+
+                log.info("==== Job '{}' 종료 - 최종 상태: {} ====",
+                        jobExecution.getJobInstance().getJobName(),
+                        jobExecution.getStatus());
             }
         };
     }
+
+    @Bean
+    public StepExecutionListener stepTimeListener() {
+        return new StepExecutionListener() {
+            @Override
+            public void beforeStep(StepExecution stepExecution) {
+                stepStartTimes.put(stepExecution.getStepName(), System.currentTimeMillis());
+            }
+
+            @Override
+            public ExitStatus afterStep(StepExecution stepExecution) {
+                return stepExecution.getExitStatus();
+            }
+        };
+    }
+
+
 }

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/AttendanceJobConfig.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/AttendanceJobConfig.java
@@ -37,10 +37,11 @@ public class AttendanceJobConfig {
     @Bean
     public Job attendanceJob() {
         return new JobBuilder("automaticTransferJob", jobRepository)
-                .listener(attendanceBatchJobListener.attendanceJobListener()) // Listener 등록
-                .start(attendanceStep()).on("*").to(statementPdfStep())
-                .from(statementPdfStep()).on("*").to(statementEmailStep())
-                .from(statementEmailStep()).on("*").end()
+                .listener(attendanceBatchJobListener.attendanceJobListener())
+                .start(attendanceStep())
+                .on("FAILED").fail()  // attendanceStep이 실패하면 Job 전체 실패
+                .from(attendanceStep()).on("COMPLETED").to(statementPdfStep())  // 성공시에만 다음 단계
+                .next(statementEmailStep())
                 .end()
                 .build();
     }

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/BatchCheckRunner.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/BatchCheckRunner.java
@@ -45,7 +45,7 @@ public class BatchCheckRunner {
             JobExecution lastExecution = jobRepository
                     .getLastJobExecution("automaticTransferJob", params);
 
-            if (lastExecution == null) {
+            if (lastExecution == null || lastExecution.getStatus().isUnsuccessful()) {
                 log.info("오늘 배치 미실행. 배치 실행");
                 jobLauncher.run(attendanceJob, params);
             }

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/attendance/SalaryBatchStep.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/attendance/SalaryBatchStep.java
@@ -84,18 +84,8 @@ public class SalaryBatchStep {
 //                TransferResponse response = feignWithCoreBank.automaticTransfer(request);
                 //수수료 입금 로직 제거
 
-                TransferResponse response = null;
-                try {
-                    //프록시 활용, 서킷 브레이커
-                    response = coreBankFeignClient.automaticTransfer(request);
-                    return BatchOutputData.of(response, item, true);
-                } catch (FeignException fe) {
-                    // 수수료 이체 실패 시 로깅 및 알림
-                    log.error("수수료 이체 실패 - amount={}, error={}", adminRequest.getAmount(), fe.getMessage());
-
-                    // 직원급여는 정상 처리된 것으로 처리
-                    return BatchOutputData.of(response, item, false);
-                }
+                TransferResponse response = coreBankFeignClient.automaticTransfer(request);
+                return BatchOutputData.of(response, item, true);
             } catch (FeignException fe) {
                 log.error("금융서버 통신 실패 - president_account={}, employee_account={}, error={}, type={}",
                         item.getFromAccount(), item.getToAccount(), fe.getMessage(), ErrorType.FEIGN_EXCEPTION.name());

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/attendance/SalaryBatchStep.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/attendance/SalaryBatchStep.java
@@ -6,6 +6,7 @@ import com.example.Attendance.error.ErrorCode;
 import com.example.Attendance.error.ErrorDTO;
 import com.example.Attendance.error.FeignExceptionHandler;
 import com.example.Attendance.error.log.ErrorType;
+import com.example.Attendance.feign.CoreBankFeignClient;
 import com.example.Attendance.feign.FeignWithCoreBank;
 import com.example.Attendance.model.Batch;
 import com.example.Attendance.repository.BatchRepository;
@@ -40,16 +41,20 @@ public class SalaryBatchStep {
     private final FeignWithCoreBank feignWithCoreBank;
     private final CalculateService calculateService;
     private final FeignExceptionHandler handler;
+    private final CoreBankFeignClient coreBankFeignClient;
 
     @Bean("salaryReader")
     public ItemReader<BatchInputData> salaryReader() {
         return () -> {
             try {
                 if (salaryBatchState.getEmployees() == null) {
+                    log.info("찾아오기 시도");
                     if (!salaryBatchState.setEmployees(storeEmployeeService.
                             findStoreEmployeeByTypeAndPaymentDate(salaryBatchState.getPaymentDay()))) {
+                        log.info("사람없음");
                         return null;
                     }
+                    log.info("찾아오기 성공");
                     salaryBatchState.setCommutes(commuteService.
                             findAllByCommuteDateBetween(salaryBatchState.getEmployeeIds(),
                                     salaryBatchState.getLocalDate()));
@@ -76,17 +81,20 @@ public class SalaryBatchStep {
                 TransferRequest request = TransferRequest.from(item);
                 TransferRequest adminRequest = TransferRequest.fromForAdmin(request);
 
-                TransferResponse response = feignWithCoreBank.automaticTransfer(request);
+//                TransferResponse response = feignWithCoreBank.automaticTransfer(request);
+                //수수료 입금 로직 제거
 
+                TransferResponse response = null;
                 try {
-                    TransferResponse responseAdmin = feignWithCoreBank.automaticTransfer(adminRequest);  // 수수료 이체
-                    return BatchOutputData.of(response, item,true);
+                    //프록시 활용, 서킷 브레이커
+                    response = coreBankFeignClient.automaticTransfer(request);
+                    return BatchOutputData.of(response, item, true);
                 } catch (FeignException fe) {
                     // 수수료 이체 실패 시 로깅 및 알림
                     log.error("수수료 이체 실패 - amount={}, error={}", adminRequest.getAmount(), fe.getMessage());
 
                     // 직원급여는 정상 처리된 것으로 처리
-                    return BatchOutputData.of(response, item,false);
+                    return BatchOutputData.of(response, item, false);
                 }
             } catch (FeignException fe) {
                 log.error("금융서버 통신 실패 - president_account={}, employee_account={}, error={}, type={}",

--- a/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/email/EmailBatchStep.java
+++ b/Attendance/src/main/java/com/example/Attendance/config/attendanceJob/step/email/EmailBatchStep.java
@@ -81,6 +81,7 @@ public class EmailBatchStep {
                         true,
                         item.getIsMask());
             } catch (Exception e) {
+                log.error("Email 처리 중 오류: ", e);
                 throw new CustomException(ErrorCode.SERVER_ERROR);
             }
         };

--- a/Attendance/src/main/java/com/example/Attendance/feign/CoreBankFeignClient.java
+++ b/Attendance/src/main/java/com/example/Attendance/feign/CoreBankFeignClient.java
@@ -1,0 +1,29 @@
+package com.example.Attendance.feign;
+
+
+import com.example.Attendance.dto.batch.TransferRequest;
+import com.example.Attendance.dto.batch.TransferResponse;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;  // 이걸로 변경
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CoreBankFeignClient {
+    private final FeignWithCoreBank feignWithCoreBank;
+    private final CircuitBreaker circuitBreaker;
+
+    public TransferResponse automaticTransfer(TransferRequest request) {
+        try {
+            return circuitBreaker.decorateSupplier(() ->
+                    feignWithCoreBank.automaticTransfer(request)
+            ).get();
+        } catch (Exception e) {
+            log.error("CoreBank 요청 실패 - 6초간 Circuit Open");
+            throw e;
+        }
+    }
+}

--- a/Attendance/src/main/java/com/example/Attendance/feign/FeignWithCoreBank.java
+++ b/Attendance/src/main/java/com/example/Attendance/feign/FeignWithCoreBank.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Component
-@FeignClient(name = "CoreBank", url = "http://3.39.182.226:3030", configuration = FeignConfig.class)
+@FeignClient(name = "CoreBank", url = "http://localhost:3030", configuration = FeignConfig.class)
 public interface FeignWithCoreBank {
 
     @PostMapping("/bank/automatictransfer")

--- a/Attendance/src/main/java/com/example/Attendance/feign/FeignWithCoreBank.java
+++ b/Attendance/src/main/java/com/example/Attendance/feign/FeignWithCoreBank.java
@@ -1,6 +1,6 @@
 package com.example.Attendance.feign;
 
-import com.example.Attendance.config.FeignConfig;
+//import com.example.Attendance.config.FeignConfig;
 import com.example.Attendance.dto.batch.TransferRequest;
 import com.example.Attendance.dto.batch.TransferResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Component
-@FeignClient(name = "CoreBank", url = "http://localhost:3030", configuration = FeignConfig.class)
+//@FeignClient(name = "CoreBank", url = "http://localhost:3030", configuration = FeignConfig.class)
+@FeignClient(name = "CoreBank", url = "http://localhost:3030")
 public interface FeignWithCoreBank {
 
     @PostMapping("/bank/automatictransfer")

--- a/Attendance/src/main/java/com/example/Attendance/feign/circuitbreaker/CircuitBreakerState.java
+++ b/Attendance/src/main/java/com/example/Attendance/feign/circuitbreaker/CircuitBreakerState.java
@@ -1,0 +1,29 @@
+//package com.example.Attendance.feign.circuitbreaker;
+//
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//@Slf4j
+//public class CircuitBreakerState {
+//    private volatile boolean isOpen = false;
+//    private volatile long openTime = 0;
+//    private final long waitDuration = 10000;
+//
+//    public boolean isCircuitOpen() {
+//        if (isOpen && System.currentTimeMillis() - openTime > waitDuration) {
+//            log.info("Circuit breaker 상태가 CLOSED로 변경됨");
+//            isOpen = false; // 대기 시간이 지나면 회로 닫기
+//            return false;
+//        }
+//        return isOpen;
+//    }
+//
+//    public void openCircuit() {
+//        log.info("Circuit breaker 상태가 OPEN으로 변경됨");
+//        isOpen = true;
+//        openTime = System.currentTimeMillis();
+//    }
+//}

--- a/Attendance/src/main/java/com/example/Attendance/feign/circuitbreaker/Resilience4jConfig.java
+++ b/Attendance/src/main/java/com/example/Attendance/feign/circuitbreaker/Resilience4jConfig.java
@@ -1,0 +1,33 @@
+package com.example.Attendance.feign.circuitbreaker;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class Resilience4jConfig {
+    @Bean
+    public CircuitBreakerConfig circuitBreakerConfig() {
+        return CircuitBreakerConfig.custom()
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(1)        // 실패시
+                .failureRateThreshold(100.0f)  // 즉시
+                .waitDurationInOpenState(Duration.ofSeconds(6))  // 6초간 서킷 브레이커 동작
+                .permittedNumberOfCallsInHalfOpenState(1)
+                .build();
+    }
+
+    @Bean
+    public CircuitBreakerRegistry circuitBreakerRegistry(CircuitBreakerConfig circuitBreakerConfig) {
+        return CircuitBreakerRegistry.of(circuitBreakerConfig);
+    }
+
+    @Bean
+    public CircuitBreaker coreBankCircuitBreaker(CircuitBreakerRegistry circuitBreakerRegistry) {
+        return circuitBreakerRegistry.circuitBreaker("coreBank");
+    }
+}

--- a/Attendance/src/main/java/com/example/Attendance/model/StoreEmployee.java
+++ b/Attendance/src/main/java/com/example/Attendance/model/StoreEmployee.java
@@ -45,7 +45,7 @@ public class StoreEmployee {
 
     @Column(name = "payment_date", nullable = false)
     @Min(1)
-    @Max(28)
+//    @Max(28)
     private Integer paymentDate;
 
 

--- a/Attendance/src/main/java/com/example/Attendance/service/EmailService.java
+++ b/Attendance/src/main/java/com/example/Attendance/service/EmailService.java
@@ -115,7 +115,8 @@ public class EmailService {
             log.info(" {}에게 급여명세서: {} 전송에 성공했습니다:", toMail, content);
         } catch (MailSendException sme)
         {
-            log.error("존재하지 않는 이메일 : {}" ,toMail);
+            String errorMessage = sme.getMessage();
+            log.error("에러 상세: {}", errorMessage);
             throw new CustomException(ErrorCode.NOT_EXISTS_EMAIL);
         }  catch (MessagingException e) {
             log.error("이메일 전송 실패: {}", e.getMessage());

--- a/Attendance/src/main/java/com/example/Attendance/service/batch/PdfService.java
+++ b/Attendance/src/main/java/com/example/Attendance/service/batch/PdfService.java
@@ -21,9 +21,9 @@ public class PdfService {
         try {
             ITextRenderer renderer = new ITextRenderer();
 
-            // 폰트 설정
-            String fontPath = "/app/fonts/NanumGothic-Regular.ttf";
-
+            // 폰트 설정 //배포 시
+//            String fontPath = "/app/fonts/NanumGothic-Regular.ttf";
+            String fontPath = "/fonts/NanumGothic-Regular.ttf";
             // 폰트 등록
             renderer.getFontResolver().addFont(
                     fontPath,

--- a/core-bank/src/main/java/com/example/core_bank/core_bank/core/service/BankCoreService.java
+++ b/core-bank/src/main/java/com/example/core_bank/core_bank/core/service/BankCoreService.java
@@ -32,19 +32,26 @@ public class BankCoreService {
 
         // 리스트 정렬해서 받음.
         // 여기 로직 더 효율적이게 변경 되어야함
-        log.info("{} {} {} ",transferRequest.getToAccount(),transferRequest.getToBankCode(),transferRequest.getToAccountDepositor());
-        log.info("{} {} {} ",transferRequest.getFromAccount(),transferRequest.getFromBankCode(),transferRequest.getFromAccountDepositor());
-        log.info("첫째");
-        Account fromAccount = findFromAccount(transferRequest);
-        log.info("둘째");
-        Account toAccount = findToAccount(transferRequest);
+        try{
 
-        validateBalance(fromAccount, transferRequest.getAmount());
+            log.info("{} {} {} ",transferRequest.getToAccount(),transferRequest.getToBankCode(),transferRequest.getToAccountDepositor());
+            log.info("{} {} {} ",transferRequest.getFromAccount(),transferRequest.getFromBankCode(),transferRequest.getFromAccountDepositor());
+            log.info("첫째");
+            Account fromAccount = findFromAccount(transferRequest);
+            log.info("둘째");
+            Account toAccount = findToAccount(transferRequest);
 
-        LocalDate now = LocalDate.now();
-        updateBalances(fromAccount, toAccount, transferRequest.getAmount());
-        createHistories(fromAccount, toAccount,transferRequest.getAmount(),now);
-        return now;
+            validateBalance(fromAccount, transferRequest.getAmount());
+
+            LocalDate now = LocalDate.now();
+            updateBalances(fromAccount, toAccount, transferRequest.getAmount());
+            createHistories(fromAccount, toAccount,transferRequest.getAmount(),now);
+            return now;
+        } catch (Exception e)
+        {
+            log.info(e.getMessage()+"오류발생");
+            return null;
+        }
     }
 
     private void updateBalances(Account fromAccount, Account toAccount, Long amount){


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/053dc428-5412-4001-baf4-0c4882232b43)
![image](https://github.com/user-attachments/assets/556a0e9c-560c-4e0c-8cd1-32dc96d4e776)

문제 상황 : 
1. Core-Bank 서버 오류 발생 시, 해당 로직을 반복하는 문제 발생
2. PDF 생성 로직이 병목 지점이 되는 문제 파악 (약 10000ms)

추가 로직 :
1. resilience4j를 활용하여 1회 요청 후 실패 시 6초간 요청을 방지하는 서킷 브레이커 구현
2. pdf 템플릿 생성 영역을 static으로 변경, 반복 객체 생성 및 메모리 할당 방지

결과 : 
1. 자동 이체 요청 중 실패 시 기존 2000~10000 ms 이상 걸리던 로직의 속도를 700ms정도로 5배 이상 개선 
2. pdf 생성 로직의 속도를 10000ms-> 4000ms 로 2배 이상 개선

![image](https://github.com/user-attachments/assets/3b7b30f5-9e5b-4af1-a8cf-c8728855cfd4)
